### PR TITLE
Set up and CoC

### DIFF
--- a/index.md
+++ b/index.md
@@ -126,7 +126,7 @@ eventbrite:           # optional: alphanumeric key for Eventbrite registration, 
   {% elsif page.carpentry == "lc" %}
   Library Carpentry's
   {% endif %}
-  <a href="{{site.swc_site}}/conduct.html">Code of Conduct</a>.
+  <a href="{{site.swc_site}}/conduct.html">Code of Conduct</a> as we follow the same practice as Carpentry.
 </p>
 
 {% comment %}
@@ -232,8 +232,8 @@ eventbrite:           # optional: alphanumeric key for Eventbrite registration, 
 <p>
   To participate in a
   {% if page.carpentry == "swc" %}
-  Software Carpentry
-  {% elsif page.carpentry == "dc" %}
+  R TidyVerse
+  {% elsif page. == "dc" %}
   Data Carpentry
   {% elsif page.carpentry == "lc" %}
   Library Carpentry


### PR DESCRIPTION
In the "Set up" section, there is a sentence starting with "to participate in a Software Carpentry workshop, you will need access to ...". In this sentence, "Software Carpentry" is changed to "R TidyVerse". Also, I think it is good to keep that the participants should abide by Carpentries Code of Conduct in this workshop as well, but I modified this part so that it is more clear that this workshop is not a Carpentries certified (?) workshop.

